### PR TITLE
Use class for the user's badge widget

### DIFF
--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -415,7 +415,7 @@
 			foreach($result as $slug) {
 				$bcount[$badges[$slug]['type']] = isset($bcount[$badges[$slug]['type']])?$bcount[$badges[$slug]['type']]+1:1; 
 			}
-			$output='<span id="badge-medals-widget">';
+			$output='<span class="badge-medals-widget">';
 			for($x = 2; $x >= 0; $x--) {
 				if(!isset($bcount[$x])) continue;
 				$count = $bcount[$x];


### PR DESCRIPTION
It was previously using an `id`, but you can't use the same
`id` on a page multiple times.  This was causing problems on
the users page.
