### PR TITLE
Add one more detail in installation instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Installation
      at the command prompt (on Linux, Windows is a bit different)
    - To download directly, go to the `project page`_ and click **Download**
 
+#. Copy the downloaded `q2a-badges` directory to the `qa-plugin` directory of your website
 #. Go to **Admin -> Plugins** on your q2a install and select the '**Activate badges**' option, then '**Save Changes**'.
 
 .. _Question2Answer: http://www.question2answer.org/install.php


### PR DESCRIPTION
Explain here where to copy the plugin directory, so that the user don't have to also skim through the Question2Answer documentation to find this information.