### PR TITLE
Fix a php warning for new users

### DIFF
--- a/qa-badge-layer.php
+++ b/qa-badge-layer.php
@@ -51,7 +51,7 @@
 					true
 				);
 
-				if(!$user['uid']) {
+				if(!isset($user['uid'])) {
 					qa_db_query_sub(
 						'INSERT INTO ^achievements (user_id, first_visit, oldest_consec_visit, longest_consec_visit, last_visit, total_days_visited, questions_read, posts_edited) VALUES (#, NOW(), NOW(), #, NOW(), #, #, #) ON DUPLICATE KEY UPDATE first_visit=NOW(), oldest_consec_visit=NOW(), longest_consec_visit=#, last_visit=NOW(), total_days_visited=#, questions_read=#, posts_edited=#',
 						$userid, 1, 1, 0, 0, 1, 1, 0, 0


### PR DESCRIPTION
Without this "isset" we get a php warning because for users who just registered
$user is null (and we try to get the field 'uid' on a null object).
(I don't know if this warning was always here or if it appears only on recent
versions of Q2A)

Note that this fix is just the same code that is used on L113 of this file
where we check if we have the field 'points'

Nb: I have no idea why we don't have a similar warning on the lines where we
    try to access the other fields of $user (eg: L67, L71, ...), that's why
    I don't try to fix anything there